### PR TITLE
Avoid deprecation warnings.

### DIFF
--- a/www/getconsent.php
+++ b/www/getconsent.php
@@ -128,8 +128,8 @@ $t->data['attributes'] = $attributes;
 $t->data['checked'] = $state['consent:checked'];
 $t->data['stateId'] = $id;
 
-$srcName = htmlspecialchars(is_array($srcName) ? $translator->t($srcName) : $srcName);
-$dstName = htmlspecialchars(is_array($dstName) ? $translator->t($dstName) : $dstName);
+$srcName = htmlspecialchars(is_array($srcName) ? $translator->getPreferredTranslation($srcName) : $srcName);
+$dstName = htmlspecialchars(is_array($dstName) ? $translator->getPreferredTranslation($dstName) : $dstName);
 
 $t->data['consent_attributes_header'] = $translator->t(
     '{consent:consent:consent_attributes_header}',


### PR DESCRIPTION
The consent module currently generates deprecation warnings in SSP 1.16 and 1.17. I beleive in the given context getPreferredTranslation() should be called instead of t() anyway.