### PR TITLE
Improve Afrikaans translation

### DIFF
--- a/dictionaries/consent.translation.json
+++ b/dictionaries/consent.translation.json
@@ -32,7 +32,7 @@
         "sr": "Da, nastavi",
         "ro": "Da, continu\u0103",
         "eu": "Bai, jarraitu",
-        "af": "Ja, voortgaan",
+        "af": "Ja, gaan voort",
         "el": "\u0391\u03c0\u03bf\u03b4\u03bf\u03c7\u03ae",
         "zu": "Yebo, qhubeka",
         "xh": "Ewe, qhubeka"

--- a/locales/af/LC_MESSAGES/consent.po
+++ b/locales/af/LC_MESSAGES/consent.po
@@ -80,7 +80,7 @@ msgid "{consent:consent:noconsent_return}"
 msgstr "Keer terug na die toestemmingsbladsy"
 
 msgid "{consent:consent:yes}"
-msgstr "Ja, voortgaan"
+msgstr "Ja, gaan voort"
 
 msgid "{consent:consent:consent_attributes_header}"
 msgstr "Informasie wat gestuur sal word na SPNAME"


### PR DESCRIPTION
Improve the translation of the "yes" button. (via Stellenbosch University library)