### PR TITLE
Fetch privacypolicy from first UIInfo PrivacyStatementURL key

### DIFF
--- a/www/getconsent.php
+++ b/www/getconsent.php
@@ -160,10 +160,12 @@ $t->data['srcName'] = $srcName;
 $t->data['dstName'] = $dstName;
 
 // Fetch privacypolicy
-if (array_key_exists('privacypolicy', $state['Destination'])) {
-    $privacypolicy = $state['Destination']['privacypolicy'];
-} elseif (array_key_exists('PrivacyStatementURL', $state['Destination']['UIInfo']) && (!empty($state['Destination']['UIInfo']['PrivacyStatementURL']))) {
+if (array_key_exists('PrivacyStatementURL', $state['Destination']['UIInfo']) && (!empty($state['Destination']['UIInfo']['PrivacyStatementURL']))) {
     $privacypolicy = reset($state['Destination']['UIInfo']['PrivacyStatementURL']);
+} elseif (array_key_exists('privacypolicy', $state['Destination'])) {
+    $privacypolicy = $state['Destination']['privacypolicy'];
+} elseif (array_key_exists('PrivacyStatementURL', $state['Source']['UIInfo']) && (!empty($state['Source']['UIInfo']['PrivacyStatementURL']))) {
+    $privacypolicy = reset($state['Source']['UIInfo']['PrivacyStatementURL']);
 } elseif (array_key_exists('privacypolicy', $state['Source'])) {
     $privacypolicy = $state['Source']['privacypolicy'];
 } else {

--- a/www/getconsent.php
+++ b/www/getconsent.php
@@ -162,6 +162,8 @@ $t->data['dstName'] = $dstName;
 // Fetch privacypolicy
 if (array_key_exists('privacypolicy', $state['Destination'])) {
     $privacypolicy = $state['Destination']['privacypolicy'];
+} elseif (array_key_exists('PrivacyStatementURL', $state['Destination']['UIInfo']) && (!empty($state['Destination']['UIInfo']['PrivacyStatementURL']))) {
+    $privacypolicy = reset($state['Destination']['UIInfo']['PrivacyStatementURL']);
 } elseif (array_key_exists('privacypolicy', $state['Source'])) {
     $privacypolicy = $state['Source']['privacypolicy'];
 } else {


### PR DESCRIPTION
Metarefresh module (https://simplesamlphp.org/docs/stable/simplesamlphp-automated_metadata) which generates saml20-sp-remote object from XML defines PrivacyPolicy URL like this:

```
[...]
$metadata['https://sp1.example.com/20190808'] = array (
  UIInfo' =>
  array (
    'PrivacyStatementURL' =>
    array (
      'en' => 'https://sp1.example/policy',
      'de' => 'https://sp1.example/policy',
    ),
  )
[...]
```

Consent module is expecting Privacy Statement URL under 'privacypolicy' option and not 'PrivacyStatementURL'. Because of different naming of option (or should I say attribute), URL is not retreived from SP metadata and so privacypolicy URL from IdP is used at Consent page.

My fix takes first value in PrivacyStatementURL array. Better solution would be, that value for current language is taken.