### PR TITLE
If session was already enabled, getconsent.php raises exception

### DIFF
--- a/www/getconsent.php
+++ b/www/getconsent.php
@@ -1,6 +1,8 @@
 <?php
 
-session_cache_limiter('nocache');
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_cache_limiter('nocache');
+}
 
 /**
  * Consent script


### PR DESCRIPTION
Hi,

I have added another consent page for users who's password is older then a specific time-period to be asked to change the password.

When this old-password-page is displayed, the PHP Session is started. If after this the consent page is also displayed, then I receive an exception because the session is already active but session_cache_limiter it tried to be set.

Therefore I added a check, if a session is not active to call the session_cache_limiter.