### PR TITLE
Change escaping strategy of privacy policy link from url to html.

### DIFF
--- a/templates/consentform.twig
+++ b/templates/consentform.twig
@@ -29,7 +29,7 @@
 
 {% if sppp != false %}
 <p>{{ '{consent:consent:consent_privacypolicy}'|trans }}
-    <a target='_blank' href='{{ sppp|escape('url') }} '>{{ dstName }}</a>
+    <a target='_blank' href='{{ sppp|escape('html') }} '>{{ dstName }}</a>
 </p>
 {% endif %}
 


### PR DESCRIPTION
Using escape strategy `url` breaks the link (result: a relative link with escaped slashes and so on). Other templates in SSP use `html`.

See also [Escape Filter](https://twig.symfony.com/doc/2.x/filters/escape.html)

> url: escapes a string for the URI or parameter contexts. This should not be used to escape an entire URI; only a subcomponent being inserted.