### PR TITLE
Make cookie parameters configurable + SameSite

### DIFF
--- a/docs/consent.md
+++ b/docs/consent.md
@@ -64,6 +64,21 @@ Example:
             'store'                => 'consent:Cookie', 
 	),
 
+If necessary, you can set the cookie parameters in the config array using the same sematics as other cookies (default values shown):
+
+	90 => array(
+            'class'                => 'consent:Consent',
+            'identifyingAttribute' => 'uid',
+            'store'                => array(
+                'consent:Cookie',
+                'name' => '\SimpleSAML\Module\consent', # prefix for name
+                'lifetime' => 7776000,
+                'path' => '/',
+                'domain' => '',
+                'secure' => true,
+                'samesite' => null,
+            ),
+	),
 
 ### Using a database as storage ###
 


### PR DESCRIPTION
When dealing with the [SameSite issue in SSP](https://github.com/simplesamlphp/simplesamlphp/pull/1161), it seems I overlooked the cookies set by this module. Fixing that required looking at changing the parameters sent for cookies, and that in turn begs the question why this module does not allow all cookie parameters to be set like other SSP cookies

This patch parameterises cookies, while still preserving the original defaults so that existing configurations are unaffected.

I've not added unit tests for this because honestly I have no idea how to unit test the setting of cookies :-/. But I did add documentation.