### PR TITLE
Use MDUI entries for description & information URL

### DIFF
--- a/docs/consent.md
+++ b/docs/consent.md
@@ -194,7 +194,8 @@ The following options can be used when configuring the Consent module:
 
 `showNoConsentAboutService`
 :   Whether we will show a link to more information about the service from the
-    no consent page (configured in the SP metadata as `url.about`). Defaults to `true`.
+    no consent page (configured in the SP metadata as the MDUI `InformationURL`).
+    Defaults to `true`.
 
 ### External options
 

--- a/src/Controller/ConsentController.php
+++ b/src/Controller/ConsentController.php
@@ -185,7 +185,14 @@ class ConsentController
         $t->data['stateId'] = $stateId;
         $t->data['source'] = $state['Source'];
         $t->data['destination'] = $state['Destination'];
-        $t->data['descr_purpose'] = $t->getEntityPropertyTranslation('descr_purpose', $state['Destination']);
+
+        if (isset($state['Destination']['descr_purpose'])) {
+            $t->data['descr_purpose'] = $state['Destination']['descr_purpose'];
+        } elseif (isset($state['Destination']['description'])) {
+            $t->data['descr_purpose'] = $state['Destination']['description'];
+        } elseif (isset($state['Destination']['UIInfo']['Description'])) {
+            $t->data['descr_purpose'] = $state['Destination']['UIInfo']['Description'];
+        }
 
         // Fetch privacy policy
         if (
@@ -262,6 +269,8 @@ class ConsentController
         if (!isset($state['consent:showNoConsentAboutService']) || $state['consent:showNoConsentAboutService']) {
             if (isset($state['Destination']['url.about'])) {
                 $aboutService = $state['Destination']['url.about'];
+            } elseif (isset($state['Destination']['UIInfo']['InformationURL'])) {
+                $aboutService = reset($state['Destination']['UIInfo']['InformationURL']);
             }
         }
 

--- a/src/Controller/ConsentController.php
+++ b/src/Controller/ConsentController.php
@@ -186,9 +186,7 @@ class ConsentController
         $t->data['source'] = $state['Source'];
         $t->data['destination'] = $state['Destination'];
 
-        if (isset($state['Destination']['descr_purpose'])) {
-            $t->data['descr_purpose'] = $state['Destination']['descr_purpose'];
-        } elseif (isset($state['Destination']['description'])) {
+        if (isset($state['Destination']['description'])) {
             $t->data['descr_purpose'] = $state['Destination']['description'];
         } elseif (isset($state['Destination']['UIInfo']['Description'])) {
             $t->data['descr_purpose'] = $state['Destination']['UIInfo']['Description'];
@@ -267,9 +265,7 @@ class ConsentController
 
         $aboutService = null;
         if (!isset($state['consent:showNoConsentAboutService']) || $state['consent:showNoConsentAboutService']) {
-            if (isset($state['Destination']['url.about'])) {
-                $aboutService = $state['Destination']['url.about'];
-            } elseif (isset($state['Destination']['UIInfo']['InformationURL'])) {
+            if (isset($state['Destination']['UIInfo']['InformationURL'])) {
                 $aboutService = reset($state['Destination']['UIInfo']['InformationURL']);
             }
         }

--- a/templates/consentform.twig
+++ b/templates/consentform.twig
@@ -9,7 +9,7 @@
 <p>{{ '%SPNAME% requires that the information below is transferred.'|trans({'%SPNAME%': destination|entityDisplayName() }) }}</p>
 
 {% if descr_purpose is defined and descr_purpose != "" %}
-    <p>{{ 'The purpose of %SPNAME% is %SPDESC%'|trans({'%SPNAME%': destination|entityDisplayName(), '%SPDESC%': descr_purpose }) }}</p>
+    <p>{{ 'The purpose of %SPNAME% is %SPDESC%'|trans({'%SPNAME%': destination|entityDisplayName(), '%SPDESC%': descr_purpose|translateFromArray }) }}</p>
 {% endif %}
 
 <form id="consent_yes" action="{{ moduleURL('consent/getconsent') }}" method="GET">

--- a/tests/src/Controller/ConsentControllerTest.php
+++ b/tests/src/Controller/ConsentControllerTest.php
@@ -172,7 +172,9 @@ class ConsentTest extends TestCase
                     'Destination' => [
                         'entityid' => 'urn:some:sp',
                         'name' => 'Some destination',
-                        'url.about' => 'https://example.org/about',
+                        'UIInfo' =>[
+                            'InformationURL' => ['https://example.org/about' ],
+                        ],
                     ],
                 ];
             }


### PR DESCRIPTION
The consent module uses non-standard metadata options of `descr_purpose` and `url.about` that don't exist anywhere in the main source or in e.g. metarefresh.

SAMLParser already creates entries for these from MDUI info array. Similarly, the [SP remote reference](https://simplesamlphp.org/docs/devel/simplesamlphp-reference-sp-remote.html) documents a `description` option. It makes sense to use these when they're available.

This was done for the privacyStatementURL in #6