### PR TITLE
Fix exception during assert

### DIFF
--- a/src/Auth/Process/Consent.php
+++ b/src/Auth/Process/Consent.php
@@ -296,7 +296,7 @@ class Consent extends Auth\ProcessingFilter
             Assert::keyExists(
                 $attributes,
                 $this->identifyingAttribute,
-                "Consent: Missing '" . $attributes[$this->identifyingAttribute] . "' in user's attributes."
+                "Consent: Missing '" . $this->identifyingAttribute . "' in user's attributes."
             );
 
             $source = $state['Source']['metadata-set'] . '|' . $idpEntityId;


### PR DESCRIPTION
A minor bug that generates an exception:

`SimpleSAML\Error\Exception: Error 2 - Array to string conversion at /home/safire/simplesamlphp-2.0.0-rc2/modules/consent/src/Auth/Process/Consent.php:299`